### PR TITLE
Fix for shifting a view by a large offset.

### DIFF
--- a/src/edu/cmu/cs/openslide/gui/OpenSlideView.java
+++ b/src/edu/cmu/cs/openslide/gui/OpenSlideView.java
@@ -148,8 +148,16 @@ public class OpenSlideView extends JPanel {
     private void translateSlidePrivate(int dX, int dY) {
         int w = dbuf.getWidth();
         int h = dbuf.getHeight();
-
         Graphics2D g = dbuf.createGraphics();
+
+        if (Math.abs(dX) >= w || Math.abs(dY) >= h) {
+            viewPosition.translate(dX, dY);
+            g.setClip(0, 0, w, h);
+            paintBackingStore(g);
+            g.dispose();
+            return;
+        }
+
         g.copyArea(0, 0, w, h, -dX, -dY);
         viewPosition.translate(dX, dY);
 


### PR DESCRIPTION
If we translate the viewport by more than the current window size,
refresh the whole window and don't try to reuse any existing image and
fill around the edges. Otherwise we end up trying to clip regions out of
the slide that are too large, resulting in cairo errors.
