### PR TITLE
Make AssociatedImageMap public and stop implementing Map

### DIFF
--- a/src/org/openslide/AssociatedImageMap.java
+++ b/src/org/openslide/AssociatedImageMap.java
@@ -1,7 +1,7 @@
 /*
  *  OpenSlide, a library for reading whole slide image files
  *
- *  Copyright (c) 2007-2009 Carnegie Mellon University
+ *  Copyright (c) 2007-2011 Carnegie Mellon University
  *  All rights reserved.
  *
  *  OpenSlide is free software: you can redistribute it and/or modify
@@ -22,146 +22,60 @@
 package org.openslide;
 
 import java.awt.image.BufferedImage;
-import java.awt.image.DataBufferInt;
 import java.io.IOException;
 import java.util.*;
 
-class AssociatedImageMap implements Map<String, BufferedImage> {
-    private static class ImageEntry implements Entry<String, BufferedImage> {
-
-        final private String key;
-
-        final private BufferedImage value;
-
-        public ImageEntry(String key, BufferedImage value) {
-            this.key = key;
-            this.value = value;
-        }
-
-        @Override
-        public String getKey() {
-            return key;
-        }
-
-        @Override
-        public BufferedImage getValue() {
-            return value;
-        }
-
-        @Override
-        public BufferedImage setValue(BufferedImage value) {
-            throw new UnsupportedOperationException();
-        }
-    }
+public class AssociatedImageMap {
 
     final private Set<String> names;
 
     final private OpenSlide os;
 
-    public AssociatedImageMap(Set<String> names, OpenSlide os) {
+    AssociatedImageMap(Set<String> names, OpenSlide os) {
         this.names = names;
         this.os = os;
     }
 
-    @Override
-    public void clear() {
-        throw new UnsupportedOperationException();
+    public boolean isEmpty() {
+        return names.isEmpty();
     }
 
-    @Override
-    public boolean containsKey(Object key) {
-        return names.contains(key);
+    public int size() {
+        return names.size();
     }
 
-    @Override
-    public boolean containsValue(Object value) {
-        if (value instanceof BufferedImage) {
-            BufferedImage biVal = (BufferedImage) value;
-
-            Collection<BufferedImage> vals = values();
-            for (BufferedImage b : vals) {
-                if (b.getWidth() != biVal.getWidth()) {
-                    return false;
-                }
-                if (b.getHeight() != biVal.getHeight()) {
-                    return false;
-                }
-                if (b.getType() != biVal.getType()) {
-                    return false;
-                }
-                int data1[] = ((DataBufferInt) b.getRaster().getDataBuffer())
-                        .getData();
-                int data2[] = ((DataBufferInt) biVal.getRaster()
-                        .getDataBuffer()).getData();
-
-                return Arrays.equals(data1, data2);
-            }
-        }
-        return false;
+    public boolean contains(String name) {
+        return names.contains(name);
     }
 
-    @Override
-    public Set<Entry<String, BufferedImage>> entrySet() {
-        Set<Entry<String, BufferedImage>> result = new HashSet<Entry<String, BufferedImage>>();
-
-        for (String name : names) {
-            Entry<String, BufferedImage> entry = new ImageEntry(name, get(name));
-            result.add(entry);
-        }
-
-        return result;
-    }
-
-    @Override
-    public BufferedImage get(Object key) {
-        if (key instanceof String && containsKey(key)) {
-            try {
-                return os.getAssociatedImage((String) key);
-            } catch (IOException e) {
-                return null;
-            }
+    public BufferedImage get(String name) throws IOException {
+        if (contains(name)) {
+            return os.getAssociatedImage(name);
         } else {
             return null;
         }
     }
 
-    @Override
-    public boolean isEmpty() {
-        return names.isEmpty();
-    }
-
-    @Override
-    public Set<String> keySet() {
+    public Set<String> getNames() {
         return names;
     }
 
     @Override
-    public BufferedImage put(String key, BufferedImage value) {
-        throw new UnsupportedOperationException();
+    public int hashCode() {
+        return os.hashCode() + 12;
     }
 
     @Override
-    public void putAll(Map<? extends String, ? extends BufferedImage> m) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public BufferedImage remove(Object key) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int size() {
-        return names.size();
-    }
-
-    @Override
-    public Collection<BufferedImage> values() {
-        List<BufferedImage> values = new ArrayList<BufferedImage>();
-        for (String name : names) {
-            values.add(get(name));
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
         }
 
-        return Collections.unmodifiableCollection(values);
+        if (obj instanceof AssociatedImageMap) {
+            AssociatedImageMap map2 = (AssociatedImageMap) obj;
+            return os.equals(map2.os);
+        }
+
+        return false;
     }
 }

--- a/src/org/openslide/OpenSlide.java
+++ b/src/org/openslide/OpenSlide.java
@@ -354,7 +354,7 @@ public final class OpenSlide implements Closeable {
         return properties;
     }
 
-    public Map<String, BufferedImage> getAssociatedImages() {
+    public AssociatedImageMap getAssociatedImages() {
         return associatedImages;
     }
 

--- a/src/org/openslide/TestCLI.java
+++ b/src/org/openslide/TestCLI.java
@@ -1,7 +1,7 @@
 /*
  *  OpenSlide, a library for reading whole slide image files
  *
- *  Copyright (c) 2007-2009 Carnegie Mellon University
+ *  Copyright (c) 2007-2011 Carnegie Mellon University
  *  All rights reserved.
  *
  *  OpenSlide is free software: you can redistribute it and/or modify
@@ -60,6 +60,13 @@ public class TestCLI {
         h = osr.getLayer0Height();
         System.out.printf("dimensions: %d x %d\n", w, h);
         System.out.printf("comment: %s\n", osr.getComment());
+
+        System.out.print("associated images:");
+        AssociatedImageMap associated = osr.getAssociatedImages();
+        for (String name : associated.getNames()) {
+            System.out.printf(" %s", name);
+        }
+        System.out.print("\n");
 
         int layers = osr.getLayerCount();
         System.out.printf("num layers: %d\n", layers);


### PR DESCRIPTION
Map.get() cannot throw, so AssociatedImageMap.get() returned null if the
associated image could not be loaded.  For consistency, we should throw
IOException in this case, so we can no longer implement Map.

Eliminate unnecessary Map methods, rename some others to improve clarity,
and throw IOException.
