### PR TITLE
Add Meson build system

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,10 +1,10 @@
 # OpenSlide Java release process
 
 - [ ] Run test build and `make distcheck`
-- [ ] Update `CHANGELOG.md` and version in `configure.ac`
+- [ ] Update `CHANGELOG.md` and versions in `configure.ac` and `meson.build`
 - [ ] Create and push signed tag
-- [ ] `git clean -dxf && autoreconf -i && ./configure && make distcheck`
-- [ ] Attach release notes to [GitHub release](https://github.com/openslide/openslide-java/releases/new), set pre-release flag, and upload tarballs
+- [ ] `git clean -dxf && meson setup builddir && meson dist -C builddir`
+- [ ] Attach release notes to [GitHub release](https://github.com/openslide/openslide-java/releases/new), set pre-release flag, and upload tarball
 - [ ] [Update openslide-winbuild](https://github.com/openslide/openslide-winbuild/issues/new?labels=release&template=release.md)
 - [ ] Update website: `_data/releases.yaml`, `_includes/news.md`
 - [ ] Send mail to -announce and -users

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -22,15 +22,17 @@ jobs:
       uses: actions/checkout@v3
     - name: Install dependencies (Linux)
       if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: sudo apt-get install libopenslide0-dev
+      run: |
+        sudo apt-get install libopenslide0-dev ninja-build
+        # Ubuntu 22.04 packages Meson 0.61
+        pip install --user meson
     - name: Install dependencies (macOS)
       if: ${{ matrix.os == 'macos-latest' }}
-      run: brew install automake openslide
+      run: brew install meson openslide
     - name: Build
       run: |
-        autoreconf -i
-        ./configure --prefix=$HOME
-        make
-        make install
+        meson setup builddir --prefix=$HOME
+        meson compile -C builddir
+        meson install -C builddir
     - name: Smoke test
-      run: java -cp openslide.jar org.openslide.TestCLI fixtures/small.svs
+      run: java -cp builddir/openslide.jar org.openslide.TestCLI fixtures/small.svs

--- a/README.md
+++ b/README.md
@@ -3,14 +3,41 @@
 This is a Java binding to [OpenSlide](https://openslide.org/).
 
 
-## Build requirements
+## Building with Meson
+
+This is the new method.
+
+### Build requirements
+
+- JDK
+- Meson &ge; 0.62
+- OpenSlide &ge; 3.4.0
+- pkg-config
+
+
+### Building
+
+```
+meson setup builddir
+meson compile -C builddir
+meson install -C builddir
+```
+
+
+## Building with Autotools and Ant
+
+This is the old method, and will eventually be removed.
+
+
+### Build requirements
 
 - JDK
 - Apache Ant
 - OpenSlide &ge; 3.4.0
+- pkg-config
 
 
-## Building on Linux or Mac OS X
+### Building on Linux or Mac OS X
 
 ```
 ./configure
@@ -22,7 +49,7 @@ make install
 autoconf, automake, libtool, and pkg-config and run `autoreconf -i`.)
 
 
-## Cross-compiling for Windows with MinGW-w64
+### Cross-compiling for Windows with MinGW-w64
 
 ```
 PKG_CONFIG=pkg-config \
@@ -35,7 +62,7 @@ make install
 For a 64-bit JRE, substitute `--host=x86_64-w64-mingw32`.
 
 
-## Building on Windows
+### Building on Windows
 
 Ensure that the path to the openslide-java source tree does not contain
 whitespace.

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,153 @@
+project(
+  'openslide-java',
+  'c', 'java',
+  default_options : [
+    'buildtype=debugoptimized',
+  ],
+  license : 'LGPL-2.1-only',
+  meson_version : '>=0.62',
+  version : '0.12.2',
+)
+meson.add_dist_script(
+  'scripts/dist.py'
+)
+java_ver = '1.8'
+
+# options
+# must be absolute path for openslide_jni_path
+install_dir = get_option('prefix') / get_option('libdir') / 'openslide-java'
+
+# Java setup
+jni = dependency(
+  'jni',
+  version : '>=' + java_ver,
+)
+if meson.is_cross_build()
+  # probably no native JNI headers available; use bundled generic ones
+  jni = declare_dependency(
+    dependencies : [jni],
+    include_directories : ['cross'],
+  )
+elif host_machine.system() == 'darwin'
+  if not meson.get_compiler('c').has_header('jni.h', dependencies : [jni])
+    # Meson < 1.0 doesn't know to check /usr/libexec/java_home
+    darwin_java_home = run_command(
+      '/usr/libexec/java_home',
+      check : true,
+    ).stdout().strip()
+    message('Using JNI headers from ' + darwin_java_home)
+    jni = declare_dependency(
+      dependencies : [jni],
+      include_directories : [
+        darwin_java_home / 'include',
+        darwin_java_home / 'include/darwin'
+      ],
+    )
+  endif
+endif
+native_java_home = meson.get_external_property(
+  'java_home',
+  '',
+  native : true
+)
+jar = find_program(
+  'jar',
+  dirs : native_java_home != '' ? [native_java_home / 'bin'] : [],
+  native : true,
+)
+
+# compiler options
+add_project_arguments(
+  '-Wno-pointer-to-int-cast',
+  '-Wno-int-to-pointer-cast',
+  language : 'c',
+)
+add_project_arguments(
+  '-source', java_ver,
+  '-target', java_ver,
+  '-Xlint:-options',
+  language : 'java',
+)
+
+# library dependencies
+openslide = dependency(
+  'openslide',
+  version : '>=3.4.0',
+)
+
+# JNI
+jni_link_args = []
+jni_prefix = []
+jni_suffix = []
+if host_machine.system() == 'windows'
+  # JNI uses stdcall without @
+  jni_link_args += '-Wl,--kill-at'
+  # skip "lib" prefix, even when built with MinGW
+  jni_prefix = ''
+elif host_machine.system() == 'darwin'
+  # special file extension for JNI libraries
+  jni_suffix = 'jnilib'
+endif
+openslide_jni = shared_module(
+  'openslide-jni',
+  'openslide-jni.c',
+  dependencies : [jni, openslide],
+  install : true,
+  install_dir : install_dir,
+  link_args : jni_link_args,
+  name_prefix : jni_prefix,
+  name_suffix : jni_suffix,
+)
+fs = import('fs')
+openslide_jni_path = install_dir / fs.name(openslide_jni.full_path())
+
+# jar
+jar_props = configure_file(
+  input : 'meta/openslide.properties.in',
+  output : 'openslide.properties',
+  configuration : {
+    # don't embed JNI library path in jar on Windows
+    'jni_path': host_machine.system() == 'windows' ? '' : openslide_jni_path,
+  }
+)
+manifest_extra = configure_file(
+  input : 'meta/MANIFEST.MF.in',
+  output : 'MANIFEST.MF',
+  configuration : {
+    'version': meson.project_version(),
+  }
+)
+built_jar = jar(
+  'built',
+  [
+    'org/openslide/gui/Annotation.java',
+    'org/openslide/gui/DefaultAnnotation.java',
+    'org/openslide/gui/DefaultSelectionListModel.java',
+    'org/openslide/gui/Demo.java',
+    'org/openslide/gui/OpenSlideView.java',
+    'org/openslide/gui/SelectionListModel.java',
+    'org/openslide/AssociatedImage.java',
+    'org/openslide/OpenSlideDisposedException.java',
+    'org/openslide/OpenSlide.java',
+    'org/openslide/OpenSlideJNI.java',
+    'org/openslide/TestCLI.java',
+  ],
+  java_resources : structured_sources(
+    [],
+    {
+      'resources': jar_props,
+    },
+  ),
+  main_class : 'org.openslide.gui.Demo',
+)
+# https://github.com/mesonbuild/meson/issues/3070
+openslide_jar = custom_target(
+  capture : true,
+  command : [jar, '-um', manifest_extra],
+  feed : true,
+  input : built_jar,
+  install : true,
+  install_dir : install_dir,
+  install_tag : 'runtime',
+  output : 'openslide.jar',
+)

--- a/meta/MANIFEST.MF.in
+++ b/meta/MANIFEST.MF.in
@@ -1,0 +1,4 @@
+Implementation-Title: OpenSlide Java
+Implementation-Vendor: OpenSlide project
+Implementation-Version: @version@
+

--- a/meta/openslide.properties.in
+++ b/meta/openslide.properties.in
@@ -1,0 +1,1 @@
+openslide.jni.path=@jni_path@

--- a/scripts/dist.py
+++ b/scripts/dist.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python3
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+base = Path(os.getenv('MESON_DIST_ROOT'))
+
+base.joinpath('.gitattributes').unlink()
+base.joinpath('.gitignore').unlink()
+base.joinpath('m4', '.gitignore').unlink()
+shutil.rmtree(base / '.github')
+
+# fixtures are currently only used by GitHub Actions
+shutil.rmtree(base / 'fixtures')
+
+subprocess.run(['autoreconf', '-i'], cwd=base, check=True)
+shutil.rmtree(base / 'autom4te.cache')


### PR DESCRIPTION
JNI include path detection and JAR custom resource support both require Meson 0.62, which isn't available in all supported OSes yet, so we'll keep Autotools+Ant build support for now.

Drop Cygwin support in Meson builds.  WSL essentially obsoletes it, and openslide-winbuild has already dropped Cygwin support.