### PR TITLE
meson: don't run dist script from subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,9 +8,11 @@ project(
   meson_version : '>=0.62',
   version : '0.12.3',
 )
-meson.add_dist_script(
-  'scripts/dist.py'
-)
+if not meson.is_subproject()
+  meson.add_dist_script(
+    'scripts/dist.py'
+  )
+endif
 java_ver = '1.8'
 
 # options


### PR DESCRIPTION
When we're a subproject and the parent project is being distributed via `meson dist --include-subprojects`, skip our dist customizations.  The subproject may have been embedded from a tarball without the dotfiles, and probably won't need Autotools support.