### PR TITLE
meson: use Git attributes to exclude files from dist tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,12 @@
 configure.ac	eol=lf
 Makefile.am	eol=lf
 *.m4		eol=lf
+
+# Don't include Git/GitHub metadata in release tarballs
+.gitattributes	export-ignore
+.gitignore	export-ignore
+/.github	export-ignore
+
+# Fixtures are currently only used by GitHub Actions.  Omit from release
+# tarballs.
+/fixtures	export-ignore

--- a/scripts/dist.py
+++ b/scripts/dist.py
@@ -7,13 +7,5 @@ import subprocess
 
 base = Path(os.getenv('MESON_DIST_ROOT'))
 
-base.joinpath('.gitattributes').unlink()
-base.joinpath('.gitignore').unlink()
-base.joinpath('m4', '.gitignore').unlink()
-shutil.rmtree(base / '.github')
-
-# fixtures are currently only used by GitHub Actions
-shutil.rmtree(base / 'fixtures')
-
 subprocess.run(['autoreconf', '-i'], cwd=base, check=True)
 shutil.rmtree(base / 'autom4te.cache')


### PR DESCRIPTION
Meson 0.60+ respects the `export-ignore` attribute, so we can drop the procedural removal.