### PR TITLE
Allow opening the synthetic slide

### DIFF
--- a/org/openslide/OpenSlide.java
+++ b/org/openslide/OpenSlide.java
@@ -99,7 +99,8 @@ public final class OpenSlide implements Closeable {
     }
 
     public OpenSlide(File file) throws IOException {
-        if (!file.exists()) {
+        // allow opening the synthetic slide
+        if (!file.exists() && !file.getPath().equals("")) {
             throw new FileNotFoundException(file.toString());
         }
 


### PR DESCRIPTION
Bypass the file-exists check if the file path is empty, allowing the synthetic test slide to be opened.  If `OPENSLIDE_DEBUG=synthetic` is not set, we'll still fail, but with an `IOException` instead of a `FileNotFoundException`.