### PR TITLE
workflows: automatically create GitHub release when tagged

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -3,8 +3,7 @@
 - [ ] Run test build and `meson dist`
 - [ ] Update `CHANGELOG.md` and versions in `configure.ac` and `meson.build`
 - [ ] Create and push signed tag
-- [ ] `git clean -dxf && meson setup builddir && meson dist -C builddir`
-- [ ] Attach release notes to [GitHub release](https://github.com/openslide/openslide-java/releases/new), set pre-release flag, and upload tarball
+- [ ] Verify that GitHub Actions created a [GitHub release](https://github.com/openslide/openslide-java/releases) with release notes and a source tarball
 - [ ] [Update openslide-bin](https://github.com/openslide/openslide-bin/issues/new?labels=release&template=release.md)
 - [ ] Update website: `_data/releases.yaml`, `_includes/news.md`
 - [ ] Send mail to -announce and -users

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -14,9 +14,14 @@ jobs:
   build:
     name: Build
     runs-on: ${{ matrix.os }}
+    outputs:
+      dist-base: ${{ steps.dist.outputs.dist-base }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            dist: dist
     steps:
     - name: Check out repo
       uses: actions/checkout@v4
@@ -36,3 +41,50 @@ jobs:
         meson install -C builddir
     - name: Smoke test
       run: java -cp builddir/openslide.jar org.openslide.TestCLI fixtures/small.svs
+    - name: Dist
+      id: dist
+      if: matrix.dist
+      run: |
+        meson dist -C builddir
+        dist="openslide-java-dist-$GITHUB_RUN_NUMBER-$(echo $GITHUB_SHA | cut -c-10)"
+        echo "dist-base=$dist" >> $GITHUB_OUTPUT
+        mkdir -p "artifacts/$dist"
+        mv builddir/meson-dist/*.tar.xz "artifacts/$dist"
+    - name: Archive dist
+      if: matrix.dist
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.dist.outputs.dist-base }}
+        path: artifacts
+        compression-level: 0
+
+  release:
+    name: Release
+    if: github.ref_type == 'tag'
+    needs: build
+    runs-on: ubuntu-latest
+    concurrency: release-${{ github.ref }}
+    permissions:
+      contents: write
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: ${{ needs.build.outputs.dist-base }}
+        merge-multiple: true
+    - name: Release to GitHub
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        version=$(echo "${{ github.ref_name }}" | sed "s/^v//")
+        tar xf "${{ needs.build.outputs.dist-base }}/openslide-java-${version}.tar.xz"
+        awk -e '/^## / && ok {exit}' \
+            -e '/^## / {ok=1; next}' \
+            -e 'ok {print}' \
+            "openslide-java-${version}/CHANGELOG.md" > changes
+        gh release create --prerelease --verify-tag \
+            --repo "${{ github.repository }}" \
+            --title "OpenSlide Java $version" \
+            --notes-file changes \
+            "${{ github.ref_name }}" \
+            "${{ needs.build.outputs.dist-base }}/"*


### PR DESCRIPTION
Run `meson dist` on Linux in every build, because it's a good idea to test this and because the build job already installs the dependencies for `meson setup`.  Archive the artifact, then conditionally run a second job to do the release.

This uses the same release-job pattern as OpenSlide Python, rather than starting a second workflow upon completion of the build workflow.  This results in a skipped job in every PR's job list, but allows the passing of output variables between jobs.

Linux builds run in `ubuntu-latest`, not in a Fedora container, so the Autotools blobs in the source tarball will be generated on Ubuntu 22.04. That release has current versions of Autoconf and Automake, so this seems okay.