### PR TITLE
Enable more compiler lints

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,7 +27,7 @@ jar = find_program(
 add_project_arguments(
   '-source', java_ver,
   '-target', java_ver,
-  '-Xlint:-options',
+  '-Xlint:all,-serial',
   language : 'java',
 )
 

--- a/org/openslide/OpenSlideFFM.java
+++ b/org/openslide/OpenSlideFFM.java
@@ -25,6 +25,7 @@ import java.lang.foreign.*;
 import static java.lang.foreign.ValueLayout.*;
 import java.lang.invoke.*;
 
+@SuppressWarnings("restricted")
 class OpenSlideFFM {
     private static final Arena LIBRARY_ARENA = Arena.ofAuto();
 

--- a/org/openslide/gui/DefaultSelectionListModel.java
+++ b/org/openslide/gui/DefaultSelectionListModel.java
@@ -27,8 +27,8 @@ import java.util.List;
 
 import javax.swing.AbstractListModel;
 
-public class DefaultSelectionListModel extends AbstractListModel implements
-        SelectionListModel {
+public class DefaultSelectionListModel extends AbstractListModel<Annotation>
+        implements SelectionListModel {
 
     private final List<Annotation> list = new ArrayList<Annotation>();
 

--- a/org/openslide/gui/OpenSlideView.java
+++ b/org/openslide/gui/OpenSlideView.java
@@ -84,6 +84,7 @@ public class OpenSlideView extends JPanel {
         this(w, 1.2, 40, startWithZoomFit);
     }
 
+    @SuppressWarnings("this-escape")
     public OpenSlideView(OpenSlide w, double downsampleBase,
             int maxDownsampleExponent, boolean startWithZoomFit) {
         // TODO support w > 2^31 and h > 2^31

--- a/org/openslide/gui/SelectionListModel.java
+++ b/org/openslide/gui/SelectionListModel.java
@@ -23,7 +23,8 @@ package org.openslide.gui;
 
 import javax.swing.ListModel;
 
-public interface SelectionListModel extends ListModel, Iterable<Annotation> {
+public interface SelectionListModel extends ListModel<Annotation>,
+        Iterable<Annotation> {
     void add(Annotation annotation);
 
     boolean isEmpty();


### PR DESCRIPTION
Leave serialization lints off; we don't care about serialization but sometimes derive from serializable classes.  Enable all other lints.

Fix missing type parameters in superclass specifications in GUI code.  Suppress warnings for restricted methods in `OpenSlideFFM`, which is expected to use them.  Suppress a this-escape warning in `OpenSlideView` caused by calls to superclass methods and not really of interest to us.