### PR TITLE
workflows: add JAR release artifact; drop source tarball

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -3,7 +3,7 @@
 - [ ] Run test build and `meson dist`
 - [ ] Update `CHANGELOG.md` and version in `meson.build`
 - [ ] Create and push signed tag
-- [ ] Verify that GitHub Actions created a [GitHub release](https://github.com/openslide/openslide-java/releases) with release notes and a source tarball
+- [ ] Verify that GitHub Actions created a [GitHub release](https://github.com/openslide/openslide-java/releases) with release notes, a source tarball, and a JAR
 - [ ] Update website: `_data/releases.yaml`, `_includes/news.md`
 - [ ] Send mail to -announce and -users
 - [ ] Post to [forum.image.sc](https://forum.image.sc/c/announcements/10)

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,9 +1,8 @@
 # OpenSlide Java release process
 
-- [ ] Run test build and `meson dist`
 - [ ] Update `CHANGELOG.md` and version in `meson.build`
 - [ ] Create and push signed tag
-- [ ] Verify that GitHub Actions created a [GitHub release](https://github.com/openslide/openslide-java/releases) with release notes, a source tarball, and a JAR
+- [ ] Verify that GitHub Actions created a [GitHub release](https://github.com/openslide/openslide-java/releases) with release notes and a JAR
 - [ ] Update website: `_data/releases.yaml`, `_includes/news.md`
 - [ ] Send mail to -announce and -users
 - [ ] Post to [forum.image.sc](https://forum.image.sc/c/announcements/10)

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -76,11 +76,9 @@ jobs:
       if: matrix.dist
       run: |
         set -o pipefail
-        meson dist -C builddir
         dist="openslide-java-dist-$GITHUB_RUN_NUMBER-$(echo $GITHUB_SHA | cut -c-10)"
         echo "dist-base=$dist" >> $GITHUB_OUTPUT
         mkdir -p "artifacts/$dist"
-        mv builddir/meson-dist/*.tar.xz "artifacts/$dist"
         version=$(meson introspect --projectinfo builddir | jq -r .version)
         mv builddir/openslide.jar \
             "artifacts/${dist}/openslide-java-${version}.jar"
@@ -101,6 +99,8 @@ jobs:
     permissions:
       contents: write
     steps:
+    - name: Check out repo
+      uses: actions/checkout@v4
     - name: Download artifacts
       uses: actions/download-artifact@v4
       with:
@@ -111,11 +111,10 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         version=$(echo "${{ github.ref_name }}" | sed "s/^v//")
-        tar xf "${{ needs.build.outputs.dist-base }}/openslide-java-${version}.tar.xz"
         awk -e '/^## / && ok {exit}' \
             -e '/^## / {ok=1; next}' \
             -e 'ok {print}' \
-            "openslide-java-${version}/CHANGELOG.md" > changes
+            CHANGELOG.md > changes
         gh release create --prerelease --verify-tag \
             --repo "${{ github.repository }}" \
             --title "OpenSlide Java $version" \

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -75,11 +75,15 @@ jobs:
       id: dist
       if: matrix.dist
       run: |
+        set -o pipefail
         meson dist -C builddir
         dist="openslide-java-dist-$GITHUB_RUN_NUMBER-$(echo $GITHUB_SHA | cut -c-10)"
         echo "dist-base=$dist" >> $GITHUB_OUTPUT
         mkdir -p "artifacts/$dist"
         mv builddir/meson-dist/*.tar.xz "artifacts/$dist"
+        version=$(meson introspect --projectinfo builddir | jq -r .version)
+        mv builddir/openslide.jar \
+            "artifacts/${dist}/openslide-java-${version}.jar"
     - name: Archive dist
       if: matrix.dist
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
The source tarball is now identical to a git-archive of the Git tag, so we can defer to the automatic "Source code" links in the GitHub release instead of uploading a separate artifact.

Now that all platforms' builds are interchangeable, add a compiled JAR release artifact.