### PR TITLE
Support OpenSlide cache management API

### DIFF
--- a/org/openslide/OpenSlide.java
+++ b/org/openslide/OpenSlide.java
@@ -2,6 +2,7 @@
  *  OpenSlide, a library for reading whole slide image files
  *
  *  Copyright (c) 2007-2011 Carnegie Mellon University
+ *  Copyright (c) 2024 Benjamin Gilbert
  *  All rights reserved.
  *
  *  OpenSlide is free software: you can redistribute it and/or modify
@@ -417,6 +418,20 @@ public final class OpenSlide implements Closeable {
             return img;
         } finally {
             rl.unlock();
+        }
+    }
+
+    public void setCache(OpenSlideCache cache) {
+        Lock cl = cache.getLock();
+        Lock rl = lock.readLock();
+        cl.lock();
+        rl.lock();
+        try {
+            checkDisposed();
+            OpenSlideFFM.openslide_set_cache(osr, cache.getSegment());
+        } finally {
+            rl.unlock();
+            cl.unlock();
         }
     }
 

--- a/org/openslide/OpenSlideCache.java
+++ b/org/openslide/OpenSlideCache.java
@@ -1,0 +1,63 @@
+/*
+ *  OpenSlide, a library for reading whole slide image files
+ *
+ *  Copyright (c) 2007-2011 Carnegie Mellon University
+ *  Copyright (c) 2024 Benjamin Gilbert
+ *  All rights reserved.
+ *
+ *  OpenSlide is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, version 2.1.
+ *
+ *  OpenSlide is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with OpenSlide. If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.openslide;
+
+import java.lang.foreign.MemorySegment;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public final class OpenSlideCache implements AutoCloseable {
+    private final Lock lock = new ReentrantLock();
+
+    private MemorySegment cache;
+
+    public OpenSlideCache(long capacity) {
+        cache = OpenSlideFFM.openslide_cache_create(capacity);
+    }
+
+    Lock getLock() {
+        return lock;
+    }
+
+    // call, and use result, with lock held
+    MemorySegment getSegment() {
+        if (cache == null) {
+            throw new OpenSlideDisposedException("OpenSlideCache");
+        }
+        return cache;
+    }
+
+    // takes the lock
+    @Override
+    public void close() {
+        lock.lock();
+        try {
+            if (cache != null) {
+                OpenSlideFFM.openslide_cache_release(cache);
+                cache = null;
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/org/openslide/OpenSlideDisposedException.java
+++ b/org/openslide/OpenSlideDisposedException.java
@@ -22,9 +22,13 @@
 package org.openslide;
 
 public class OpenSlideDisposedException extends RuntimeException {
-    private static final String MSG = "OpenSlide object has been disposed";
+    private static final String MSG = " object has been closed";
 
     public OpenSlideDisposedException() {
-        super(MSG);
+        this("OpenSlide");
+    }
+
+    public OpenSlideDisposedException(String what) {
+        super(what + MSG);
     }
 }

--- a/org/openslide/OpenSlideFFM.java
+++ b/org/openslide/OpenSlideFFM.java
@@ -102,7 +102,7 @@ class OpenSlideFFM {
             ret = (MemorySegment) detect_vendor.invokeExact(
                     arena.allocateFrom(filename));
         } catch (Throwable ex) {
-           throw new AssertionError("Invalid call", ex);
+            throw new AssertionError("Invalid call", ex);
         }
         if (ret.equals(MemorySegment.NULL)) {
             return null;
@@ -122,7 +122,7 @@ class OpenSlideFFM {
             ret = (MemorySegment) open.invokeExact(
                     arena.allocateFrom(filename));
         } catch (Throwable ex) {
-           throw new AssertionError("Invalid call", ex);
+            throw new AssertionError("Invalid call", ex);
         }
         if (ret.equals(MemorySegment.NULL)) {
             return null;
@@ -137,7 +137,7 @@ class OpenSlideFFM {
         try {
             return (int) get_level_count.invokeExact(osr);
         } catch (Throwable ex) {
-           throw new AssertionError("Invalid call", ex);
+            throw new AssertionError("Invalid call", ex);
         }
     }
 
@@ -153,7 +153,7 @@ class OpenSlideFFM {
             try {
                 get_level_dimensions.invokeExact(osr, level, w, h);
             } catch (Throwable ex) {
-               throw new AssertionError("Invalid call", ex);
+                throw new AssertionError("Invalid call", ex);
             }
             dim[0] = w.get(JAVA_LONG, 0);
             dim[1] = h.get(JAVA_LONG, 0);
@@ -167,7 +167,7 @@ class OpenSlideFFM {
         try {
             return (double) get_level_downsample.invokeExact(osr, level);
         } catch (Throwable ex) {
-           throw new AssertionError("Invalid call", ex);
+            throw new AssertionError("Invalid call", ex);
         }
     }
 
@@ -182,7 +182,7 @@ class OpenSlideFFM {
             try {
                 read_region.invokeExact(osr, buf, x, y, level, w, h);
             } catch (Throwable ex) {
-               throw new AssertionError("Invalid call", ex);
+                throw new AssertionError("Invalid call", ex);
             }
             MemorySegment.copy(buf, JAVA_INT, 0, dest, 0, dest.length);
         }
@@ -195,7 +195,7 @@ class OpenSlideFFM {
         try {
             close.invokeExact(osr);
         } catch (Throwable ex) {
-           throw new AssertionError("Invalid call", ex);
+            throw new AssertionError("Invalid call", ex);
         }
     }
 
@@ -207,7 +207,7 @@ class OpenSlideFFM {
         try {
             ret = (MemorySegment) get_error.invokeExact(osr);
         } catch (Throwable ex) {
-           throw new AssertionError("Invalid call", ex);
+            throw new AssertionError("Invalid call", ex);
         }
         if (ret.equals(MemorySegment.NULL)) {
             return null;
@@ -223,7 +223,7 @@ class OpenSlideFFM {
         try {
             ret = (MemorySegment) get_property_names.invokeExact(osr);
         } catch (Throwable ex) {
-           throw new AssertionError("Invalid call", ex);
+            throw new AssertionError("Invalid call", ex);
         }
         return segment_to_string_array(ret);
     }
@@ -240,7 +240,7 @@ class OpenSlideFFM {
             ret = (MemorySegment) get_property_value.invokeExact(osr,
                     arena.allocateFrom(name));
         } catch (Throwable ex) {
-           throw new AssertionError("Invalid call", ex);
+            throw new AssertionError("Invalid call", ex);
         }
         if (ret.equals(MemorySegment.NULL)) {
             return null;
@@ -256,7 +256,7 @@ class OpenSlideFFM {
         try {
             ret = (MemorySegment) get_associated_image_names.invokeExact(osr);
         } catch (Throwable ex) {
-           throw new AssertionError("Invalid call", ex);
+            throw new AssertionError("Invalid call", ex);
         }
         return segment_to_string_array(ret);
     }
@@ -277,7 +277,7 @@ class OpenSlideFFM {
                 get_associated_image_dimensions.invokeExact(osr,
                         arena.allocateFrom(name), w, h);
             } catch (Throwable ex) {
-               throw new AssertionError("Invalid call", ex);
+                throw new AssertionError("Invalid call", ex);
             }
             dim[0] = w.get(JAVA_LONG, 0);
             dim[1] = h.get(JAVA_LONG, 0);
@@ -299,7 +299,7 @@ class OpenSlideFFM {
                 read_associated_image.invokeExact(osr, arena.allocateFrom(name),
                         buf);
             } catch (Throwable ex) {
-               throw new AssertionError("Invalid call", ex);
+                throw new AssertionError("Invalid call", ex);
             }
             MemorySegment.copy(buf, JAVA_INT, 0, dest, 0, dest.length);
         }
@@ -313,7 +313,7 @@ class OpenSlideFFM {
         try {
             ret = (MemorySegment) get_version.invokeExact();
         } catch (Throwable ex) {
-           throw new AssertionError("Invalid call", ex);
+            throw new AssertionError("Invalid call", ex);
         }
         return ret.getString(0);
     }

--- a/org/openslide/OpenSlideFFM.java
+++ b/org/openslide/OpenSlideFFM.java
@@ -34,6 +34,9 @@ class OpenSlideFFM {
     private static final AddressLayout C_POINTER = ADDRESS.withTargetLayout(
             MemoryLayout.sequenceLayout(Long.MAX_VALUE, JAVA_BYTE));
 
+    private static final MemoryLayout SIZE_T = Linker.nativeLinker()
+            .canonicalLayouts().get("size_t");
+
     private OpenSlideFFM() {
     }
 
@@ -302,6 +305,39 @@ class OpenSlideFFM {
                 throw new AssertionError("Invalid call", ex);
             }
             MemorySegment.copy(buf, JAVA_INT, 0, dest, 0, dest.length);
+        }
+    }
+
+    private static final MethodHandle cache_create = function(
+            C_POINTER, "openslide_cache_create", SIZE_T);
+
+    static MemorySegment openslide_cache_create(long capacity) {
+        try {
+            return (MemorySegment) cache_create.invokeExact(capacity);
+        } catch (Throwable ex) {
+            throw new AssertionError("Invalid call", ex);
+        }
+    }
+
+    private static final MethodHandle set_cache = function(
+            null, "openslide_set_cache", C_POINTER, C_POINTER);
+
+    static void openslide_set_cache(MemorySegment osr, MemorySegment cache) {
+        try {
+            set_cache.invokeExact(osr, cache);
+        } catch (Throwable ex) {
+            throw new AssertionError("Invalid call", ex);
+        }
+    }
+
+    private static final MethodHandle cache_release = function(
+            null, "openslide_cache_release", C_POINTER);
+
+    static void openslide_cache_release(MemorySegment cache) {
+        try {
+            cache_release.invokeExact(cache);
+        } catch (Throwable ex) {
+            throw new AssertionError("Invalid call", ex);
         }
     }
 

--- a/org/openslide/TestCLI.java
+++ b/org/openslide/TestCLI.java
@@ -56,7 +56,10 @@ public class TestCLI {
 
         osr.dispose();
 
-        osr = new OpenSlide(f);
+        try (OpenSlideCache cache = new OpenSlideCache(64 << 20)) {
+            osr = new OpenSlide(f);
+            osr.setCache(cache);
+        }
 
         w = osr.getLevel0Width();
         h = osr.getLevel0Height();


### PR DESCRIPTION
Use the same semantics as the OpenSlide API.

The `OpenSlide` class implements `java.io.Closeable`, which is documented to be for `a source or destination of data that can be closed`.  `OpenSlideCache` is technically a source or destination of data, but not at the Java API level, and the only reason it needs to be closeable is to release the underlying resource in the C API.  Its superinterface `java.lang.AutoCloseable` is documented to be for `an object that may hold resources [...] until it is closed`; implement that instead.

OpenSlide has a legacy `dispose()` method which is an alias for `close()`.  Don't add a similar method to `OpenSlideCache`.

Closes: https://github.com/openslide/openslide-java/issues/36