### PR TITLE
Automatically clean up leaked `openslide_t`/`openslide_cache_t` refs

### DIFF
--- a/org/openslide/OpenSlide.java
+++ b/org/openslide/OpenSlide.java
@@ -189,7 +189,7 @@ public final class OpenSlide implements Closeable {
         wl.lock();
         try {
             if (osr != null) {
-                OpenSlideFFM.openslide_close(osr);
+                osr.close();
                 osr = null;
             }
         } finally {

--- a/org/openslide/OpenSlide.java
+++ b/org/openslide/OpenSlide.java
@@ -77,7 +77,7 @@ public final class OpenSlide implements Closeable {
 
     final public static String PROPERTY_NAME_VENDOR = "openslide.vendor";
 
-    private java.lang.foreign.MemorySegment osr;
+    private OpenSlideFFM.OpenSlideRef osr;
 
     final private ReadWriteLock lock = new ReentrantReadWriteLock();
 
@@ -428,7 +428,7 @@ public final class OpenSlide implements Closeable {
         rl.lock();
         try {
             checkDisposed();
-            OpenSlideFFM.openslide_set_cache(osr, cache.getSegment());
+            OpenSlideFFM.openslide_set_cache(osr, cache.getRef());
         } finally {
             rl.unlock();
             cl.unlock();

--- a/org/openslide/OpenSlideCache.java
+++ b/org/openslide/OpenSlideCache.java
@@ -22,14 +22,13 @@
 
 package org.openslide;
 
-import java.lang.foreign.MemorySegment;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 public final class OpenSlideCache implements AutoCloseable {
     private final Lock lock = new ReentrantLock();
 
-    private MemorySegment cache;
+    private OpenSlideFFM.OpenSlideCacheRef cache;
 
     public OpenSlideCache(long capacity) {
         cache = OpenSlideFFM.openslide_cache_create(capacity);
@@ -40,7 +39,7 @@ public final class OpenSlideCache implements AutoCloseable {
     }
 
     // call, and use result, with lock held
-    MemorySegment getSegment() {
+    OpenSlideFFM.OpenSlideCacheRef getRef() {
         if (cache == null) {
             throw new OpenSlideDisposedException("OpenSlideCache");
         }

--- a/org/openslide/OpenSlideCache.java
+++ b/org/openslide/OpenSlideCache.java
@@ -52,7 +52,7 @@ public final class OpenSlideCache implements AutoCloseable {
         lock.lock();
         try {
             if (cache != null) {
-                OpenSlideFFM.openslide_cache_release(cache);
+                cache.close();
                 cache = null;
             }
         } finally {

--- a/org/openslide/OpenSlideFFM.java
+++ b/org/openslide/OpenSlideFFM.java
@@ -81,6 +81,30 @@ class OpenSlideFFM {
         return Linker.nativeLinker().downcallHandle(symbol, desc);
     }
 
+    private static abstract class Ref {
+        private final MemorySegment segment;
+
+        Ref(MemorySegment segment) {
+            this.segment = segment;
+        }
+
+        MemorySegment getSegment() {
+            return segment;
+        }
+    }
+
+    static class OpenSlideRef extends Ref {
+        OpenSlideRef(MemorySegment segment) {
+            super(segment);
+        }
+    }
+
+    static class OpenSlideCacheRef extends Ref {
+        OpenSlideCacheRef(MemorySegment segment) {
+            super(segment);
+        }
+    }
+
     private static String[] segment_to_string_array(MemorySegment seg) {
         int length = 0;
         while (!seg.getAtIndex(C_POINTER, length).equals(MemorySegment.NULL)) {
@@ -116,7 +140,7 @@ class OpenSlideFFM {
     private static final MethodHandle open = function(
             C_POINTER, "openslide_open", C_POINTER);
 
-    static MemorySegment openslide_open(String filename) {
+    static OpenSlideRef openslide_open(String filename) {
         if (filename == null) {
             return null;
         }
@@ -130,15 +154,15 @@ class OpenSlideFFM {
         if (ret.equals(MemorySegment.NULL)) {
             return null;
         }
-        return ret;
+        return new OpenSlideRef(ret);
     }
 
     private static final MethodHandle get_level_count = function(
             JAVA_INT, "openslide_get_level_count", C_POINTER);
 
-    static int openslide_get_level_count(MemorySegment osr) {
+    static int openslide_get_level_count(OpenSlideRef osr) {
         try {
-            return (int) get_level_count.invokeExact(osr);
+            return (int) get_level_count.invokeExact(osr.getSegment());
         } catch (Throwable ex) {
             throw new AssertionError("Invalid call", ex);
         }
@@ -148,13 +172,13 @@ class OpenSlideFFM {
             null, "openslide_get_level_dimensions", C_POINTER, JAVA_INT,
             C_POINTER, C_POINTER);
 
-    static void openslide_get_level_dimensions(MemorySegment osr, int level,
+    static void openslide_get_level_dimensions(OpenSlideRef osr, int level,
             long dim[]) {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment w = arena.allocateFrom(JAVA_LONG, 0);
             MemorySegment h = arena.allocateFrom(JAVA_LONG, 0);
             try {
-                get_level_dimensions.invokeExact(osr, level, w, h);
+                get_level_dimensions.invokeExact(osr.getSegment(), level, w, h);
             } catch (Throwable ex) {
                 throw new AssertionError("Invalid call", ex);
             }
@@ -166,9 +190,10 @@ class OpenSlideFFM {
     private static final MethodHandle get_level_downsample = function(
             JAVA_DOUBLE, "openslide_get_level_downsample", C_POINTER, JAVA_INT);
 
-    static double openslide_get_level_downsample(MemorySegment osr, int level) {
+    static double openslide_get_level_downsample(OpenSlideRef osr, int level) {
         try {
-            return (double) get_level_downsample.invokeExact(osr, level);
+            return (double) get_level_downsample.invokeExact(osr.getSegment(),
+                    level);
         } catch (Throwable ex) {
             throw new AssertionError("Invalid call", ex);
         }
@@ -178,12 +203,13 @@ class OpenSlideFFM {
             null, "openslide_read_region", C_POINTER, C_POINTER,
             JAVA_LONG, JAVA_LONG, JAVA_INT, JAVA_LONG, JAVA_LONG);
 
-    static void openslide_read_region(MemorySegment osr, int dest[],
+    static void openslide_read_region(OpenSlideRef osr, int dest[],
             long x, long y, int level, long w, long h) {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment buf = arena.allocate(JAVA_INT, dest.length);
             try {
-                read_region.invokeExact(osr, buf, x, y, level, w, h);
+                read_region.invokeExact(osr.getSegment(), buf, x, y,
+                        level, w, h);
             } catch (Throwable ex) {
                 throw new AssertionError("Invalid call", ex);
             }
@@ -194,9 +220,9 @@ class OpenSlideFFM {
     private static final MethodHandle close = function(
             null, "openslide_close", C_POINTER);
 
-    static void openslide_close(MemorySegment osr) {
+    static void openslide_close(OpenSlideRef osr) {
         try {
-            close.invokeExact(osr);
+            close.invokeExact(osr.getSegment());
         } catch (Throwable ex) {
             throw new AssertionError("Invalid call", ex);
         }
@@ -205,10 +231,10 @@ class OpenSlideFFM {
     private static final MethodHandle get_error = function(
             C_POINTER, "openslide_get_error", C_POINTER);
 
-    static String openslide_get_error(MemorySegment osr) {
+    static String openslide_get_error(OpenSlideRef osr) {
         MemorySegment ret;
         try {
-            ret = (MemorySegment) get_error.invokeExact(osr);
+            ret = (MemorySegment) get_error.invokeExact(osr.getSegment());
         } catch (Throwable ex) {
             throw new AssertionError("Invalid call", ex);
         }
@@ -221,10 +247,11 @@ class OpenSlideFFM {
     private static final MethodHandle get_property_names = function(
             C_POINTER, "openslide_get_property_names", C_POINTER);
 
-    static String[] openslide_get_property_names(MemorySegment osr) {
+    static String[] openslide_get_property_names(OpenSlideRef osr) {
         MemorySegment ret;
         try {
-            ret = (MemorySegment) get_property_names.invokeExact(osr);
+            ret = (MemorySegment) get_property_names.invokeExact(
+                    osr.getSegment());
         } catch (Throwable ex) {
             throw new AssertionError("Invalid call", ex);
         }
@@ -234,14 +261,14 @@ class OpenSlideFFM {
     private static final MethodHandle get_property_value = function(
             C_POINTER, "openslide_get_property_value", C_POINTER, C_POINTER);
 
-    static String openslide_get_property_value(MemorySegment osr, String name) {
+    static String openslide_get_property_value(OpenSlideRef osr, String name) {
         if (name == null) {
             return null;
         }
         MemorySegment ret;
         try (Arena arena = Arena.ofConfined()) {
-            ret = (MemorySegment) get_property_value.invokeExact(osr,
-                    arena.allocateFrom(name));
+            ret = (MemorySegment) get_property_value.invokeExact(
+                    osr.getSegment(), arena.allocateFrom(name));
         } catch (Throwable ex) {
             throw new AssertionError("Invalid call", ex);
         }
@@ -254,10 +281,11 @@ class OpenSlideFFM {
     private static final MethodHandle get_associated_image_names = function(
             C_POINTER, "openslide_get_associated_image_names", C_POINTER);
 
-    static String[] openslide_get_associated_image_names(MemorySegment osr) {
+    static String[] openslide_get_associated_image_names(OpenSlideRef osr) {
         MemorySegment ret;
         try {
-            ret = (MemorySegment) get_associated_image_names.invokeExact(osr);
+            ret = (MemorySegment) get_associated_image_names.invokeExact(
+                    osr.getSegment());
         } catch (Throwable ex) {
             throw new AssertionError("Invalid call", ex);
         }
@@ -268,7 +296,7 @@ class OpenSlideFFM {
             null, "openslide_get_associated_image_dimensions", C_POINTER,
             C_POINTER, C_POINTER, C_POINTER);
 
-    static void openslide_get_associated_image_dimensions(MemorySegment osr,
+    static void openslide_get_associated_image_dimensions(OpenSlideRef osr,
             String name, long dim[]) {
         if (name == null) {
             return;
@@ -277,7 +305,7 @@ class OpenSlideFFM {
             MemorySegment w = arena.allocateFrom(JAVA_LONG, 0);
             MemorySegment h = arena.allocateFrom(JAVA_LONG, 0);
             try {
-                get_associated_image_dimensions.invokeExact(osr,
+                get_associated_image_dimensions.invokeExact(osr.getSegment(),
                         arena.allocateFrom(name), w, h);
             } catch (Throwable ex) {
                 throw new AssertionError("Invalid call", ex);
@@ -291,7 +319,7 @@ class OpenSlideFFM {
             null, "openslide_read_associated_image", C_POINTER, C_POINTER,
             C_POINTER);
 
-    static void openslide_read_associated_image(MemorySegment osr, String name,
+    static void openslide_read_associated_image(OpenSlideRef osr, String name,
             int dest[]) {
         if (name == null) {
             return;
@@ -299,8 +327,8 @@ class OpenSlideFFM {
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment buf = arena.allocate(JAVA_INT, dest.length);
             try {
-                read_associated_image.invokeExact(osr, arena.allocateFrom(name),
-                        buf);
+                read_associated_image.invokeExact(osr.getSegment(),
+                        arena.allocateFrom(name), buf);
             } catch (Throwable ex) {
                 throw new AssertionError("Invalid call", ex);
             }
@@ -311,20 +339,22 @@ class OpenSlideFFM {
     private static final MethodHandle cache_create = function(
             C_POINTER, "openslide_cache_create", SIZE_T);
 
-    static MemorySegment openslide_cache_create(long capacity) {
+    static OpenSlideCacheRef openslide_cache_create(long capacity) {
+        MemorySegment ret;
         try {
-            return (MemorySegment) cache_create.invokeExact(capacity);
+            ret = (MemorySegment) cache_create.invokeExact(capacity);
         } catch (Throwable ex) {
             throw new AssertionError("Invalid call", ex);
         }
+        return new OpenSlideCacheRef(ret);
     }
 
     private static final MethodHandle set_cache = function(
             null, "openslide_set_cache", C_POINTER, C_POINTER);
 
-    static void openslide_set_cache(MemorySegment osr, MemorySegment cache) {
+    static void openslide_set_cache(OpenSlideRef osr, OpenSlideCacheRef cache) {
         try {
-            set_cache.invokeExact(osr, cache);
+            set_cache.invokeExact(osr.getSegment(), cache.getSegment());
         } catch (Throwable ex) {
             throw new AssertionError("Invalid call", ex);
         }
@@ -333,9 +363,9 @@ class OpenSlideFFM {
     private static final MethodHandle cache_release = function(
             null, "openslide_cache_release", C_POINTER);
 
-    static void openslide_cache_release(MemorySegment cache) {
+    static void openslide_cache_release(OpenSlideCacheRef cache) {
         try {
-            cache_release.invokeExact(cache);
+            cache_release.invokeExact(cache.getSegment());
         } catch (Throwable ex) {
             throw new AssertionError("Invalid call", ex);
         }


### PR DESCRIPTION
Call `openslide_close()`/`openslide_cache_release()` from a `Cleaner`, ensuring we don't leak a handle if `OpenSlide.close()`/`OpenSlideCache.close()` is not called.  Move the handle into a separate `Wrapper` class; we can't implement the cleanup `Runnable` directly on `Ref` because then the `Cleaner` would keep the `Ref` alive.

The `OpenSlide.close()`/`OpenSlideCache.close()` methods are still the preferred way to release an object, since they're explicit and eager.