### PR TITLE
Refactor several items

### DIFF
--- a/org/openslide/OpenSlide.java
+++ b/org/openslide/OpenSlide.java
@@ -188,14 +188,20 @@ public final class OpenSlide implements Closeable {
                 hashCodeVal = canonicalFile.hashCode();
             }
         } catch (IOException e) {
-            // dispose, we are in the constructor
-            dispose();
+            // close, we are in the constructor
+            close();
             throw e;
         }
     }
 
-    public void dispose() {
+    @Override
+    public void close() {
         errorCtx.getOsr().close();
+    }
+
+    @Deprecated
+    public void dispose() {
+        close();
     }
 
     public int getLevelCount() {
@@ -444,10 +450,5 @@ public final class OpenSlide implements Closeable {
         }
 
         return false;
-    }
-
-    @Override
-    public void close() {
-        dispose();
     }
 }

--- a/org/openslide/OpenSlideCache.java
+++ b/org/openslide/OpenSlideCache.java
@@ -22,41 +22,19 @@
 
 package org.openslide;
 
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
 public final class OpenSlideCache implements AutoCloseable {
-    private final Lock lock = new ReentrantLock();
-
-    private OpenSlideFFM.OpenSlideCacheRef cache;
+    private final OpenSlideFFM.OpenSlideCacheRef cache;
 
     public OpenSlideCache(long capacity) {
         cache = OpenSlideFFM.openslide_cache_create(capacity);
     }
 
-    Lock getLock() {
-        return lock;
-    }
-
-    // call, and use result, with lock held
     OpenSlideFFM.OpenSlideCacheRef getRef() {
-        if (cache == null) {
-            throw new OpenSlideDisposedException("OpenSlideCache");
-        }
         return cache;
     }
 
-    // takes the lock
     @Override
     public void close() {
-        lock.lock();
-        try {
-            if (cache != null) {
-                cache.close();
-                cache = null;
-            }
-        } finally {
-            lock.unlock();
-        }
+        cache.close();
     }
 }

--- a/org/openslide/OpenSlideDisposedException.java
+++ b/org/openslide/OpenSlideDisposedException.java
@@ -24,6 +24,7 @@ package org.openslide;
 public class OpenSlideDisposedException extends RuntimeException {
     private static final String MSG = " object has been closed";
 
+    @Deprecated
     public OpenSlideDisposedException() {
         this("OpenSlide");
     }

--- a/org/openslide/OpenSlideFFM.java
+++ b/org/openslide/OpenSlideFFM.java
@@ -129,7 +129,7 @@ class OpenSlideFFM {
                 try {
                     close.invokeExact(getSegment());
                 } catch (Throwable ex) {
-                    throw new AssertionError("Invalid call", ex);
+                    throw wrapException(ex);
                 }
             }
         }
@@ -153,7 +153,7 @@ class OpenSlideFFM {
                 try {
                     cache_release.invokeExact(getSegment());
                 } catch (Throwable ex) {
-                    throw new AssertionError("Invalid call", ex);
+                    throw wrapException(ex);
                 }
             }
         }
@@ -175,6 +175,13 @@ class OpenSlideFFM {
         return ret;
     }
 
+    private static RuntimeException wrapException(Throwable ex) {
+        if (ex instanceof RuntimeException) {
+            return (RuntimeException) ex;
+        }
+        return new IllegalArgumentException("Invalid call", ex);
+    }
+
     private static final MethodHandle detect_vendor = function(
             C_POINTER, "openslide_detect_vendor", C_POINTER);
 
@@ -187,7 +194,7 @@ class OpenSlideFFM {
             ret = (MemorySegment) detect_vendor.invokeExact(
                     arena.allocateFrom(filename));
         } catch (Throwable ex) {
-            throw new AssertionError("Invalid call", ex);
+            throw wrapException(ex);
         }
         if (ret.equals(MemorySegment.NULL)) {
             return null;
@@ -207,7 +214,7 @@ class OpenSlideFFM {
             ret = (MemorySegment) open.invokeExact(
                     arena.allocateFrom(filename));
         } catch (Throwable ex) {
-            throw new AssertionError("Invalid call", ex);
+            throw wrapException(ex);
         }
         if (ret.equals(MemorySegment.NULL)) {
             return null;
@@ -222,7 +229,7 @@ class OpenSlideFFM {
         try {
             return (int) get_level_count.invokeExact(osr.getSegment());
         } catch (Throwable ex) {
-            throw new AssertionError("Invalid call", ex);
+            throw wrapException(ex);
         }
     }
 
@@ -238,7 +245,7 @@ class OpenSlideFFM {
             try {
                 get_level_dimensions.invokeExact(osr.getSegment(), level, w, h);
             } catch (Throwable ex) {
-                throw new AssertionError("Invalid call", ex);
+                throw wrapException(ex);
             }
             dim[0] = w.get(JAVA_LONG, 0);
             dim[1] = h.get(JAVA_LONG, 0);
@@ -253,7 +260,7 @@ class OpenSlideFFM {
             return (double) get_level_downsample.invokeExact(osr.getSegment(),
                     level);
         } catch (Throwable ex) {
-            throw new AssertionError("Invalid call", ex);
+            throw wrapException(ex);
         }
     }
 
@@ -269,7 +276,7 @@ class OpenSlideFFM {
                 read_region.invokeExact(osr.getSegment(), buf, x, y,
                         level, w, h);
             } catch (Throwable ex) {
-                throw new AssertionError("Invalid call", ex);
+                throw wrapException(ex);
             }
             MemorySegment.copy(buf, JAVA_INT, 0, dest, 0, dest.length);
         }
@@ -283,7 +290,7 @@ class OpenSlideFFM {
         try {
             ret = (MemorySegment) get_error.invokeExact(osr.getSegment());
         } catch (Throwable ex) {
-            throw new AssertionError("Invalid call", ex);
+            throw wrapException(ex);
         }
         if (ret.equals(MemorySegment.NULL)) {
             return null;
@@ -300,7 +307,7 @@ class OpenSlideFFM {
             ret = (MemorySegment) get_property_names.invokeExact(
                     osr.getSegment());
         } catch (Throwable ex) {
-            throw new AssertionError("Invalid call", ex);
+            throw wrapException(ex);
         }
         return segment_to_string_array(ret);
     }
@@ -317,7 +324,7 @@ class OpenSlideFFM {
             ret = (MemorySegment) get_property_value.invokeExact(
                     osr.getSegment(), arena.allocateFrom(name));
         } catch (Throwable ex) {
-            throw new AssertionError("Invalid call", ex);
+            throw wrapException(ex);
         }
         if (ret.equals(MemorySegment.NULL)) {
             return null;
@@ -334,7 +341,7 @@ class OpenSlideFFM {
             ret = (MemorySegment) get_associated_image_names.invokeExact(
                     osr.getSegment());
         } catch (Throwable ex) {
-            throw new AssertionError("Invalid call", ex);
+            throw wrapException(ex);
         }
         return segment_to_string_array(ret);
     }
@@ -355,7 +362,7 @@ class OpenSlideFFM {
                 get_associated_image_dimensions.invokeExact(osr.getSegment(),
                         arena.allocateFrom(name), w, h);
             } catch (Throwable ex) {
-                throw new AssertionError("Invalid call", ex);
+                throw wrapException(ex);
             }
             dim[0] = w.get(JAVA_LONG, 0);
             dim[1] = h.get(JAVA_LONG, 0);
@@ -377,7 +384,7 @@ class OpenSlideFFM {
                 read_associated_image.invokeExact(osr.getSegment(),
                         arena.allocateFrom(name), buf);
             } catch (Throwable ex) {
-                throw new AssertionError("Invalid call", ex);
+                throw wrapException(ex);
             }
             MemorySegment.copy(buf, JAVA_INT, 0, dest, 0, dest.length);
         }
@@ -391,7 +398,7 @@ class OpenSlideFFM {
         try {
             ret = (MemorySegment) cache_create.invokeExact(capacity);
         } catch (Throwable ex) {
-            throw new AssertionError("Invalid call", ex);
+            throw wrapException(ex);
         }
         return new OpenSlideCacheRef(ret);
     }
@@ -403,7 +410,7 @@ class OpenSlideFFM {
         try {
             set_cache.invokeExact(osr.getSegment(), cache.getSegment());
         } catch (Throwable ex) {
-            throw new AssertionError("Invalid call", ex);
+            throw wrapException(ex);
         }
     }
 
@@ -415,7 +422,7 @@ class OpenSlideFFM {
         try {
             ret = (MemorySegment) get_version.invokeExact();
         } catch (Throwable ex) {
-            throw new AssertionError("Invalid call", ex);
+            throw wrapException(ex);
         }
         return ret.getString(0);
     }

--- a/org/openslide/TestCLI.java
+++ b/org/openslide/TestCLI.java
@@ -54,7 +54,7 @@ public class TestCLI {
 
         long w, h;
 
-        osr.dispose();
+        osr.close();
 
         try (OpenSlideCache cache = new OpenSlideCache(64 << 20)) {
             osr = new OpenSlide(f);
@@ -83,6 +83,6 @@ public class TestCLI {
         test_next_biggest(osr, 1000);
         test_next_biggest(osr, 10000);
 
-        osr.dispose();
+        osr.close();
     }
 }


### PR DESCRIPTION
Only wrap FFM exceptions if necessary.  Exceptions from FFM invocations are generally `RuntimeExceptions`, so we can throw them as-is.  Any others we need to wrap.  In the latter case, wrap with an `IllegalArgumentException`, since that's a better guess at the cause than `AssertionError`.

Push locking down into `OpenSlideFFM`.  Implement read-write locking for use-after-free checks in a single place in `OpenSlideFFM.Ref`, which is logically a better place for it and simplifies the higher-level code.

Deprecate the now-unused, but public, zero-argument `OpenSlideDisposedException` constructor.

Use `AutoCloseable` wrapper class for OpenSlide error checks.  Rather than manually calling `checkError()` after every set of OpenSlide calls, introduce a wrapper class which holds the `OpenSlideRef` and can be used as a resource in a try-with-resources block.  When exiting the block, its `close()` method can then run the error check.

Deprecate `OpenSlide.dispose()`.  `close()` is more idiomatic because of `Closeable` and has existed since 2010.