### PR TITLE
workflows: update Brew formulae before installing deps

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -42,6 +42,7 @@ jobs:
     - name: Install dependencies (macOS)
       if: matrix.os == 'macos-14'
       run: |
+        brew update
         brew install openslide
         # allow smoke test to find OpenSlide
         echo "DYLD_LIBRARY_PATH=/opt/homebrew/lib" >> $GITHUB_ENV


### PR DESCRIPTION
The `macos-14` image currently contains a broken gdk-pixbuf formula.