### PR TITLE
Support reading ICC color profiles

### DIFF
--- a/org/openslide/OpenSlide.java
+++ b/org/openslide/OpenSlide.java
@@ -288,11 +288,8 @@ public final class OpenSlide implements Closeable {
             return;
         }
 
-        BufferedImage img = new BufferedImage(levelW, levelH,
-                BufferedImage.TYPE_INT_ARGB_PRE);
-
-        int data[] = ((DataBufferInt) img.getRaster().getDataBuffer())
-                .getData();
+        BufferedImage img = createARGBBufferedImage(levelW, levelH);
+        int data[] = getARGBPixels(img);
 
         paintRegionARGB(data, baseX, baseY, level, img.getWidth(), img
                 .getHeight());
@@ -396,11 +393,8 @@ public final class OpenSlide implements Closeable {
             throw new IOException("Failure reading associated image");
         }
 
-        BufferedImage img = new BufferedImage((int) dim[0], (int) dim[1],
-                BufferedImage.TYPE_INT_ARGB_PRE);
-
-        int data[] = ((DataBufferInt) img.getRaster().getDataBuffer())
-                .getData();
+        BufferedImage img = createARGBBufferedImage((int) dim[0], (int) dim[1]);
+        int data[] = getARGBPixels(img);
 
         try (errorCtx) {
             OpenSlideFFM.openslide_read_associated_image(errorCtx.getOsr(),
@@ -450,5 +444,14 @@ public final class OpenSlide implements Closeable {
         }
 
         return false;
+    }
+
+    private static BufferedImage createARGBBufferedImage(int w, int h) {
+        return new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB_PRE);
+    }
+
+    private static int[] getARGBPixels(BufferedImage img) {
+        DataBufferInt buf = (DataBufferInt) img.getRaster().getDataBuffer();
+        return buf.getData();
     }
 }

--- a/org/openslide/OpenSlide.java
+++ b/org/openslide/OpenSlide.java
@@ -246,6 +246,14 @@ public final class OpenSlide implements Closeable {
         }
     }
 
+    public BufferedImage readRegion(long x, long y, int level, int w, int h)
+            throws IOException {
+        BufferedImage img = createARGBBufferedImage(w, h);
+        int data[] = getARGBPixels(img);
+        paintRegionARGB(data, x, y, level, w, h);
+        return img;
+    }
+
     public void paintRegion(Graphics2D g, int dx, int dy, long sx, long sy,
             int w, int h, double downsample) throws IOException {
         if (downsample < 1.0) {
@@ -288,11 +296,7 @@ public final class OpenSlide implements Closeable {
             return;
         }
 
-        BufferedImage img = createARGBBufferedImage(levelW, levelH);
-        int data[] = getARGBPixels(img);
-
-        paintRegionARGB(data, baseX, baseY, level, img.getWidth(), img
-                .getHeight());
+        BufferedImage img = readRegion(baseX, baseY, level, levelW, levelH);
 
         // g.scale(1.0 / relativeDS, 1.0 / relativeDS);
         g.drawImage(img, dx, dy, w, h, null);

--- a/org/openslide/OpenSlideFFM.java
+++ b/org/openslide/OpenSlideFFM.java
@@ -330,6 +330,32 @@ class OpenSlideFFM {
         }
     }
 
+    private static final MethodHandle get_icc_profile_size = function(
+            JAVA_LONG, "openslide_get_icc_profile_size", C_POINTER);
+
+    static long openslide_get_icc_profile_size(OpenSlideRef osr) {
+        try (Ref.ScopedLock l = osr.lock()) {
+            return (long) get_icc_profile_size.invokeExact(osr.getSegment());
+        } catch (Throwable ex) {
+            throw wrapException(ex);
+        }
+    }
+
+    private static final MethodHandle read_icc_profile = function(
+            null, "openslide_read_icc_profile", C_POINTER, C_POINTER);
+
+    static void openslide_read_icc_profile(OpenSlideRef osr, byte dest[]) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment buf = arena.allocate(JAVA_BYTE, dest.length);
+            try (Ref.ScopedLock l = osr.lock()) {
+                read_icc_profile.invokeExact(osr.getSegment(), buf);
+            } catch (Throwable ex) {
+                throw wrapException(ex);
+            }
+            MemorySegment.copy(buf, JAVA_BYTE, 0, dest, 0, dest.length);
+        }
+    }
+
     private static final MethodHandle get_error = function(
             C_POINTER, "openslide_get_error", C_POINTER);
 
@@ -435,6 +461,44 @@ class OpenSlideFFM {
                 throw wrapException(ex);
             }
             MemorySegment.copy(buf, JAVA_INT, 0, dest, 0, dest.length);
+        }
+    }
+
+    private static final MethodHandle get_associated_image_icc_profile_size = function(
+            JAVA_LONG, "openslide_get_associated_image_icc_profile_size",
+            C_POINTER, C_POINTER);
+
+    static long openslide_get_associated_image_icc_profile_size(
+            OpenSlideRef osr, String name) {
+        if (name == null) {
+            return -1;
+        }
+        try (Arena arena = Arena.ofConfined(); Ref.ScopedLock l = osr.lock()) {
+            return (long) get_associated_image_icc_profile_size.invokeExact(
+                    osr.getSegment(), arena.allocateFrom(name));
+        } catch (Throwable ex) {
+            throw wrapException(ex);
+        }
+    }
+
+    private static final MethodHandle read_associated_image_icc_profile = function(
+            null, "openslide_read_associated_image_icc_profile", C_POINTER,
+            C_POINTER, C_POINTER);
+
+    static void openslide_read_associated_image_icc_profile(OpenSlideRef osr,
+            String name, byte dest[]) {
+        if (name == null) {
+            return;
+        }
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment buf = arena.allocate(JAVA_BYTE, dest.length);
+            try (Ref.ScopedLock l = osr.lock()) {
+                read_associated_image_icc_profile.invokeExact(osr.getSegment(),
+                        arena.allocateFrom(name), buf);
+            } catch (Throwable ex) {
+                throw wrapException(ex);
+            }
+            MemorySegment.copy(buf, JAVA_BYTE, 0, dest, 0, dest.length);
         }
     }
 


### PR DESCRIPTION
`BufferedImage` uses an sRGB `ColorModel` by default.  If a slide pyramid or associated image has an ICC profile, attach a `ColorModel` containing that profile to all `BufferedImage`s produced from that image.

Callers of `paintRegionARGB()` don't receive a `BufferedImage`.  For those users, add `OpenSlide.getColorModel()` so the profile can be read separately.  To simplify reading slide regions with a `ColorModel`, add an `OpenSlide.readRegion()` method that returns a `BufferedImage`.

`Graphics2D`'s documentation suggests that it handles color management, but its `drawImage()` method apparently does not.  If we therefore manually invoke a `ColorConvertOp` in `paintRegion()`, the `DICOM/Leica-4` [test slide](https://openslide.cs.cmu.edu/download/openslide-testdata/DICOM/Leica-4.zip) throws an exception:

    Exception in thread "AWT-EventQueue-0" java.awt.color.CMMException: LCMS error 13: Couldn't link the profiles
        at java.desktop/sun.java2d.cmm.lcms.LCMS.createNativeTransform(Native Method)
        at java.desktop/sun.java2d.cmm.lcms.LCMS.createTransform(LCMS.java:113)
        at java.desktop/sun.java2d.cmm.lcms.LCMSTransform.doTransform(LCMSTransform.java:114)
        at java.desktop/sun.java2d.cmm.lcms.LCMSTransform.colorConvert(LCMSTransform.java:149)
        at java.desktop/java.awt.image.ColorConvertOp.ICCBIFilter(ColorConvertOp.java:350)
        at java.desktop/java.awt.image.ColorConvertOp.filter(ColorConvertOp.java:277)
        at org.openslide.OpenSlide.paintRegion(OpenSlide.java:326)
        [...]

It seems that `ColorConvertOp` [always uses](https://bugs.openjdk.org/browse/JDK-8216369) perceptual rendering intent, not the default intent encoded in the profile.  Not all profiles support perceptual rendering, which may be the cause of the exception.  If we're going to automatically perform color conversion, we should do it predictably, not just when the Java CMS glue happens to do the right thing.  For now, don't try to do color conversion, either in `paintRegion()` or any of the GUI code.

Closes: https://github.com/openslide/openslide-java/issues/53