### PR TITLE
Small FFM race fix and small cleanup

### DIFF
--- a/org/openslide/OpenSlideFFM.java
+++ b/org/openslide/OpenSlideFFM.java
@@ -356,14 +356,16 @@ class OpenSlideFFM {
     static String openslide_get_error(OpenSlideRef osr) {
         MemorySegment ret;
         try (Ref.ScopedLock l = osr.lock()) {
-            ret = (MemorySegment) get_error.invokeExact(osr.getSegment());
-        } catch (Throwable ex) {
-            throw wrapException(ex);
+            try {
+                ret = (MemorySegment) get_error.invokeExact(osr.getSegment());
+            } catch (Throwable ex) {
+                throw wrapException(ex);
+            }
+            if (ret.equals(MemorySegment.NULL)) {
+                return null;
+            }
+            return ret.getString(0);
         }
-        if (ret.equals(MemorySegment.NULL)) {
-            return null;
-        }
-        return ret.getString(0);
     }
 
     private static final MethodHandle get_property_names = function(
@@ -372,12 +374,14 @@ class OpenSlideFFM {
     static String[] openslide_get_property_names(OpenSlideRef osr) {
         MemorySegment ret;
         try (Ref.ScopedLock l = osr.lock()) {
-            ret = (MemorySegment) get_property_names.invokeExact(
-                    osr.getSegment());
-        } catch (Throwable ex) {
-            throw wrapException(ex);
+            try {
+                ret = (MemorySegment) get_property_names.invokeExact(
+                        osr.getSegment());
+            } catch (Throwable ex) {
+                throw wrapException(ex);
+            }
+            return segment_to_string_array(ret);
         }
-        return segment_to_string_array(ret);
     }
 
     private static final MethodHandle get_property_value = function(
@@ -385,16 +389,18 @@ class OpenSlideFFM {
 
     static String openslide_get_property_value(OpenSlideRef osr, String name) {
         MemorySegment ret;
-        try (Arena arena = Arena.ofConfined(); Ref.ScopedLock l = osr.lock()) {
-            ret = (MemorySegment) get_property_value.invokeExact(
-                    osr.getSegment(), arena.allocateFrom(name));
-        } catch (Throwable ex) {
-            throw wrapException(ex);
+        try (Ref.ScopedLock l = osr.lock()) {
+            try (Arena arena = Arena.ofConfined()) {
+                ret = (MemorySegment) get_property_value.invokeExact(
+                        osr.getSegment(), arena.allocateFrom(name));
+            } catch (Throwable ex) {
+                throw wrapException(ex);
+            }
+            if (ret.equals(MemorySegment.NULL)) {
+                return null;
+            }
+            return ret.getString(0);
         }
-        if (ret.equals(MemorySegment.NULL)) {
-            return null;
-        }
-        return ret.getString(0);
     }
 
     private static final MethodHandle get_associated_image_names = function(
@@ -403,12 +409,14 @@ class OpenSlideFFM {
     static String[] openslide_get_associated_image_names(OpenSlideRef osr) {
         MemorySegment ret;
         try (Ref.ScopedLock l = osr.lock()) {
-            ret = (MemorySegment) get_associated_image_names.invokeExact(
-                    osr.getSegment());
-        } catch (Throwable ex) {
-            throw wrapException(ex);
+            try {
+                ret = (MemorySegment) get_associated_image_names.invokeExact(
+                        osr.getSegment());
+            } catch (Throwable ex) {
+                throw wrapException(ex);
+            }
+            return segment_to_string_array(ret);
         }
-        return segment_to_string_array(ret);
     }
 
     private static final MethodHandle get_associated_image_dimensions = function(

--- a/org/openslide/OpenSlideFFM.java
+++ b/org/openslide/OpenSlideFFM.java
@@ -234,9 +234,6 @@ class OpenSlideFFM {
             C_POINTER, "openslide_detect_vendor", C_POINTER);
 
     static String openslide_detect_vendor(String filename) {
-        if (filename == null) {
-            return null;
-        }
         MemorySegment ret;
         try (Arena arena = Arena.ofConfined()) {
             ret = (MemorySegment) detect_vendor.invokeExact(
@@ -254,9 +251,6 @@ class OpenSlideFFM {
             C_POINTER, "openslide_open", C_POINTER);
 
     static OpenSlideRef openslide_open(String filename) {
-        if (filename == null) {
-            return null;
-        }
         MemorySegment ret;
         try (Arena arena = Arena.ofConfined()) {
             ret = (MemorySegment) open.invokeExact(
@@ -390,9 +384,6 @@ class OpenSlideFFM {
             C_POINTER, "openslide_get_property_value", C_POINTER, C_POINTER);
 
     static String openslide_get_property_value(OpenSlideRef osr, String name) {
-        if (name == null) {
-            return null;
-        }
         MemorySegment ret;
         try (Arena arena = Arena.ofConfined(); Ref.ScopedLock l = osr.lock()) {
             ret = (MemorySegment) get_property_value.invokeExact(
@@ -426,9 +417,6 @@ class OpenSlideFFM {
 
     static void openslide_get_associated_image_dimensions(OpenSlideRef osr,
             String name, long dim[]) {
-        if (name == null) {
-            return;
-        }
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment w = arena.allocateFrom(JAVA_LONG, 0);
             MemorySegment h = arena.allocateFrom(JAVA_LONG, 0);
@@ -449,9 +437,6 @@ class OpenSlideFFM {
 
     static void openslide_read_associated_image(OpenSlideRef osr, String name,
             int dest[]) {
-        if (name == null) {
-            return;
-        }
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment buf = arena.allocate(JAVA_INT, dest.length);
             try (Ref.ScopedLock l = osr.lock()) {
@@ -470,9 +455,6 @@ class OpenSlideFFM {
 
     static long openslide_get_associated_image_icc_profile_size(
             OpenSlideRef osr, String name) {
-        if (name == null) {
-            return -1;
-        }
         try (Arena arena = Arena.ofConfined(); Ref.ScopedLock l = osr.lock()) {
             return (long) get_associated_image_icc_profile_size.invokeExact(
                     osr.getSegment(), arena.allocateFrom(name));
@@ -487,9 +469,6 @@ class OpenSlideFFM {
 
     static void openslide_read_associated_image_icc_profile(OpenSlideRef osr,
             String name, byte dest[]) {
-        if (name == null) {
-            return;
-        }
         try (Arena arena = Arena.ofConfined()) {
             MemorySegment buf = arena.allocate(JAVA_BYTE, dest.length);
             try (Ref.ScopedLock l = osr.lock()) {


### PR DESCRIPTION
When OpenSlide returns a pointer to a structure inside the `openslide_t`, we need to hold the `OpenSlideRef` lock until we're done copying out the returned data.  This prevents another thread from closing the `openslide_t` out from under us.

Drop redundant `OpenSlideFFM` null checks.  These were carried over from the JNI implementation, where they were needed to prevent segfaults.  With FFM, each of the affected variables is passed to `arena.allocateFrom()`, which properly throws a `NullPointerException` on `null`.  That seems more correct than returning a method-specific sentinel value, since none of these methods should ever receive `null` in normal operation.