### PR TITLE
workflows: switch from `macos-14` to `macos-latest`

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -18,7 +18,7 @@ jobs:
       dist-base: ${{ steps.dist.outputs.dist-base }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
             dist: dist
@@ -40,7 +40,7 @@ jobs:
         sudo add-apt-repository "ppa:openslide/openslide"
         sudo apt-get install libopenslide1
     - name: Install dependencies (macOS)
-      if: matrix.os == 'macos-14'
+      if: matrix.os == 'macos-latest'
       run: |
         brew update
         brew install openslide


### PR DESCRIPTION
The latter is now an alias for the former.  Switch back so we get future OS updates.