### PR TITLE
maven: switch to `maven.compiler.release`

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -19,8 +19,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        java: [22, 23]
         include:
           - os: ubuntu-latest
+            java: 22
             dist: dist
     defaults:
       run:
@@ -32,7 +34,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: oracle
-        java-version: 22
+        java-version: ${{ matrix.java }}
         cache: maven
     - name: Install dependencies (Linux)
       if: matrix.os == 'ubuntu-latest'

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>22</maven.compiler.source>
-    <maven.compiler.target>22</maven.compiler.target>
+    <maven.compiler.release>22</maven.compiler.release>
   </properties>
 
   <build>


### PR DESCRIPTION
Build with `--release` instead of `-source` and `-target`, to ensure we use the correct language rules and system classes.  Fixes build warning on Java > 22:
    
    Warning:  location of system modules is not set in conjunction with -source 22
      not setting the location of system modules may lead to class files that cannot run on JDK 22
      --release 22 is recommended instead of -source 22 -target 22 because it sets the location of system modules automatically

Run CI on both the minimum supported and latest Java.