### PR TITLE
workflows: update to Java 24; test on Linux aarch64

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -18,7 +18,7 @@ jobs:
       dist-base: ${{ steps.dist.outputs.dist-base }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         java: [22, 23]
         include:
           - os: ubuntu-latest
@@ -37,7 +37,7 @@ jobs:
         java-version: ${{ matrix.java }}
         cache: maven
     - name: Install dependencies (Linux)
-      if: matrix.os == 'ubuntu-latest'
+      if: startsWith(matrix.os, 'ubuntu-')
       run: |
         sudo add-apt-repository "ppa:openslide/openslide"
         sudo apt-get install libopenslide1

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
-        java: [22, 23]
+        java: [22, 24]
         include:
           - os: ubuntu-latest
             java: 22


### PR DESCRIPTION
aarch64 probably won't give meaningful additional CI coverage, but it doesn't hurt either.