### PR TITLE
workflows: drop `awk -e` from release job

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -129,9 +129,7 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         version=$(echo "${{ github.ref_name }}" | sed "s/^v//")
-        awk -e '/^## / && ok {exit}' \
-            -e '/^## / {ok=1; next}' \
-            -e 'ok {print}' \
+        awk '/^## / && ok {exit} /^## / {ok=1; next} ok {print}' \
             CHANGELOG.md > changes
         gh release create --prerelease --verify-tag \
             --repo "${{ github.repository }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Notable Changes in OpenSlide Java
 
-## Version 0.13.2, 2026-06-07
+## Version 0.13.3, 2026-06-07
 
 * Add constant for `openslide.barcode` property
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <version>0.13.2</version>
+  <version>0.13.3</version>
 
   <groupId>org.openslide</groupId>
   <artifactId>openslide-java</artifactId>


### PR DESCRIPTION
ubuntu-slim has mawk, which doesn't support `-e`.