### PR TITLE
workflows: switch release job back to ubuntu-latest

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -112,7 +112,7 @@ jobs:
     name: Release
     if: github.ref_type == 'tag'
     needs: build
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     concurrency: release-${{ github.ref }}
     permissions:
       contents: write
@@ -129,7 +129,9 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         version=$(echo "${{ github.ref_name }}" | sed "s/^v//")
-        awk '/^## / && ok {exit} /^## / {ok=1; next} ok {print}' \
+        awk -e '/^## / && ok {exit}' \
+            -e '/^## / {ok=1; next}' \
+            -e 'ok {print}' \
             CHANGELOG.md > changes
         gh release create --prerelease --verify-tag \
             --repo "${{ github.repository }}" \


### PR DESCRIPTION
Repos that push to PyPI can't use ubuntu-slim for their release jobs, so it's cleaner to just use ubuntu-latest in all repos.